### PR TITLE
Tweak HUD odometer (Pt.2)

### DIFF
--- a/RoadTrip_Render.ino
+++ b/RoadTrip_Render.ino
@@ -86,21 +86,12 @@ void renderHud() {
         uint8_t digits[5] = {};
         extractDigits(digits, gamePlayVars.distance / 10);
         
-        for (uint8_t i = 0, x2 = 84 ; i < 5; ++i, x2 -= 6) {
+        for (uint8_t i = 0, x2 = 82 ; i < 4; ++i, x2 -= 6) {
             Sprites::drawOverwrite(x2, 1, Images::numbers_white, digits[i]);
         }
 
-        Sprites::drawOverwrite(90, 1, Images::numbers_black, gamePlayVars.distance % 10);
-        arduboy.drawFastHLine(60, 9, 37, BLACK); // Lower horizontal line of frame
-
-        // Draw right vertical line of frame
-        if (gamePlayVars.getTimeOfDay() == TimeOfDay::Day) {
-            arduboy.drawFastVLine(96, 1, 8, BLACK);
-        }
-        else {
-           arduboy.drawFastVLine(97, 2, 7, BLACK);
-           arduboy.drawFastVLine(96, 2, 7, WHITE);
-        }
+        Sprites::drawOverwrite(88, 1, Images::numbers_black, gamePlayVars.distance % 10);
+        arduboy.drawFastHLine(64, 9, 31, BLACK); // Lower horizontal line of frame
 
     }
 

--- a/src/images/Numbers.h
+++ b/src/images/Numbers.h
@@ -86,7 +86,7 @@ const uint8_t PROGMEM numbers_white[] = {
 
 
 const uint8_t PROGMEM numbers_black[] = {
-    6, 8,
+    7, 8,
 
     // #048 Number '0' (U+0030 Digit Zero)
     0x00,  // ░░░░░░░░
@@ -94,6 +94,7 @@ const uint8_t PROGMEM numbers_black[] = {
     0x38,  // ░░▓▓▓░░░
     0x44,  // ░▓░░░▓░░
     0x38,  // ░░▓▓▓░░░
+    0x00,  // ░░░░░░░░
     0x00,  // ░░░░░░░░
     
     // #049 Number '1' (U+0031 Digit One)
@@ -103,7 +104,8 @@ const uint8_t PROGMEM numbers_black[] = {
     0x7C,  // ░▓▓▓▓▓░░
     0x40,  // ░▓░░░░░░
     0x00,  // ░░░░░░░░
-    
+    0x00,  // ░░░░░░░░
+
     // #050 Number '2' (U+0032 Digit Two)
     0x00,  // ░░░░░░░░
     0x00,  // ░░░░░░░░
@@ -111,7 +113,8 @@ const uint8_t PROGMEM numbers_black[] = {
     0x54,  // ░▓░▓░▓░░
     0x48,  // ░▓░░▓░░░
     0x00,  // ░░░░░░░░
-    
+    0x00,  // ░░░░░░░░
+
     // #051 Number '3' (U+0033 Digit Three)
     0x00,  // ░░░░░░░░
     0x00,  // ░░░░░░░░
@@ -119,7 +122,8 @@ const uint8_t PROGMEM numbers_black[] = {
     0x54,  // ░▓░▓░▓░░
     0x28,  // ░░▓░▓░░░
     0x00,  // ░░░░░░░░
-    
+    0x00,  // ░░░░░░░░
+
     // #052 Number '4' (U+0034 Digit Four)
     0x00,  // ░░░░░░░░
     0x00,  // ░░░░░░░░
@@ -127,7 +131,8 @@ const uint8_t PROGMEM numbers_black[] = {
     0x28,  // ░░▓░▓░░░
     0x7C,  // ░▓▓▓▓▓░░
     0x00,  // ░░░░░░░░
-    
+    0x00,  // ░░░░░░░░
+
     // #053 Number '5' (U+0035 Digit Five)
     0x00,  // ░░░░░░░░
     0x00,  // ░░░░░░░░
@@ -135,7 +140,8 @@ const uint8_t PROGMEM numbers_black[] = {
     0x54,  // ░▓░▓░▓░░
     0x24,  // ░░▓░░▓░░
     0x00,  // ░░░░░░░░
-    
+    0x00,  // ░░░░░░░░
+
     // #054 Number '6' (U+0036 Digit Six)
     0x00,  // ░░░░░░░░
     0x00,  // ░░░░░░░░
@@ -143,7 +149,8 @@ const uint8_t PROGMEM numbers_black[] = {
     0x54,  // ░▓░▓░▓░░
     0x20,  // ░░▓░░░░░
     0x00,  // ░░░░░░░░
-    
+    0x00,  // ░░░░░░░░
+
     // #055 Number '7' (U+0037 Digit Seven)
     0x00,  // ░░░░░░░░
     0x00,  // ░░░░░░░░
@@ -151,7 +158,8 @@ const uint8_t PROGMEM numbers_black[] = {
     0x74,  // ░▓▓▓░▓░░
     0x0C,  // ░░░░▓▓░░
     0x00,  // ░░░░░░░░
-    
+    0x00,  // ░░░░░░░░
+
     // #056 Number '8' (U+0038 Digit Eight)
     0x00,  // ░░░░░░░░
     0x00,  // ░░░░░░░░
@@ -159,12 +167,15 @@ const uint8_t PROGMEM numbers_black[] = {
     0x54,  // ░▓░▓░▓░░
     0x28,  // ░░▓░▓░░░
     0x00,  // ░░░░░░░░
-    
+    0x00,  // ░░░░░░░░
+
     // #057 Number '9' (U+0039 Digit Nine)
     0x00,  // ░░░░░░░░
     0x00,  // ░░░░░░░░
     0x08,  // ░░░░▓░░░
     0x54,  // ░▓░▓░▓░░
     0x38,  // ░░▓▓▓░░░
+    0x00,  // ░░░░░░░░
     0x00   // ░░░░░░░░
+
 };


### PR DESCRIPTION
Remove code for drawing the right side of odometer frame; the frame pixels are added to the bitmap font. This saves ~44 bytes, a few cycles faster per frame, but removes the night time ‘highlight’ on the odometer.

Remove the extra digit (leading zero) and re-center the graphic. This may save a few cycles per frame but alters the HUD visuals.