### PR TITLE
Tweak HUD gears

### DIFF
--- a/RoadTrip_Render.ino
+++ b/RoadTrip_Render.ino
@@ -18,19 +18,14 @@ void renderHud() {
                         Sprites::drawPlusMask(11 + ((frame % 3) - 1), 7 + ((frame % 3) - 1), Images::Gearbox_Knob, 0);
                         break;
 
-                    case 1 ... 5:
-                        Sprites::drawPlusMask(pgm_read_byte(&Constants::GearboxX[car.getGear()]), pgm_read_byte(&Constants::GearboxY[car.getGear()]), Images::Gearbox_Knob, 0);
+                    default: // Gears 1 ... 5
+                        Sprites::drawPlusMask(pgm_read_byte(&Constants::GearboxX[car.getGear()]), (car.getGear() % 2) ? 1 : 13, Images::Gearbox_Knob, 0);
                         break;
-
-                    default: break;
-
                 }
-
             }
-            
             break;
 
-        case TransmissionType::Auto:
+        default: // TransmissionType::Auto:
         
             Sprites::drawExternalMask(1, 1, Images::AutoD, Images::AutoMask, 0, 0);
             Sprites::drawOverwrite(18, 6, Images::AutoNumbers, car.getGear() - 1);

--- a/src/utils/Constants.h
+++ b/src/utils/Constants.h
@@ -61,7 +61,6 @@ namespace Constants {
     constexpr uint16_t GearsMax[] = { Gear0Max, Gear1Max, Gear2Max, Gear3Max, Gear4Max, Gear5Max };
 
     constexpr uint8_t PROGMEM GearboxX[] = { 0, 5, 5, 11, 11, 17 };
-    constexpr uint8_t PROGMEM GearboxY[] = { 0, 1, 13, 1, 13, 1 };
 
     constexpr uint8_t NewDayBannerDelay = 100;
     constexpr uint8_t NewDayBannerDelay_CountDown = 130;


### PR DESCRIPTION
- Removed GearboxY array. Now calculated with modulus and ternary. May be faster (despite modulus operation) as RAM is faster than PROGMEM access. (-6 bytes)
- Change main `car.getTransmissionType()` switch statement to use default case. (-4 bytes)
- Change `Manual car.getGear()` switch statement to use default case. (-4 bytes)